### PR TITLE
Strip spaces from secret data

### DIFF
--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
 	core "k8s.io/api/core/v1"
@@ -33,8 +34,8 @@ func InitCloudflareApi(ctx context.Context, c client.Client, gatewayClassName st
 		return nil, nil, err
 	}
 
-	account := cloudflare.AccountIdentifier(string(secret.Data["ACCOUNT_ID"]))
-	api, err := cloudflare.NewWithAPIToken(string(secret.Data["TOKEN"]))
+	account := cloudflare.AccountIdentifier(strings.TrimSpace(string(secret.Data["ACCOUNT_ID"])))
+	api, err := cloudflare.NewWithAPIToken(strings.TrimSpace(string(secret.Data["TOKEN"])))
 	if err != nil {
 		log.Error(err, "unable to initialize Cloudflare API from token")
 		return nil, nil, err


### PR DESCRIPTION
The README shows how to create the cloudflare secret using literals, which may persist in shell history. Another method is to write the values to files (using `--from-file=`) and `shred` the files after the secret is created. This currently doesn't work because a newline can be appended to the end of the values. Spaces and newlines are not valid characters for cloudflare accounts or tokens, so we can safely trim them when reading the secret values. This change makes the secrets more flexible and robust to user errors.