### PR TITLE
fix: Handle other gatewayclasses gracefully

### DIFF
--- a/internal/controller/gatewayclass_controller.go
+++ b/internal/controller/gatewayclass_controller.go
@@ -49,6 +49,12 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
+	// check if GatewayClass controllerName is ours
+	if gatewayClass.Spec.ControllerName != controllerName {
+		log.Info("Ignoring gatewayclass with non-matching controllerName")
+		return ctrl.Result{}, nil
+	}
+
 	// validate parameters
 	var ok bool
 	_, api, err := InitCloudflareApi(ctx, r.Client, gatewayClass.Name)


### PR DESCRIPTION
In v0.6.0 the controller panics when reconciling a gatewayclass that isn't one of ours. This adds a check similar to the one for the gateway reconciler to ensure we only reconcile if the controllerName matches the one we expect.