### PR TITLE
fix: Allow cloudflared ICMP proxy feature

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,3 +11,5 @@ kos:
     platforms:
       - all
     main: ./cmd
+    # default chainguard image only supports amd64/arm64
+    base_image: gcr.io/distroless/static-debian12:nonroot

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -599,6 +599,12 @@ func (r *GatewayReconciler) deploymentForGateway(
 						SeccompProfile: &corev1.SeccompProfile{
 							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},
+						Sysctls: []corev1.Sysctl{
+							{
+								Name:  "net.ipv4.ping_group_range",
+								Value: "0 0",
+							},
+						},
 					},
 					Containers: []corev1.Container{{
 						Image:           image,


### PR DESCRIPTION
When starting the cloudflared pod, the following is warning appears in the logs:

```text
WRN The user running cloudflared process has a GID (group ID) that is not within ping_group_range. You might need to add that user to a group within that range, or instead update the range to encompass a group the user is already in by modifying /proc/sys/net/ipv4/ping_group_range. Otherwise cloudflared will not be able to ping this network error="Group ID 0 is not between ping group 1 to 0"
WRN ICMP proxy feature is disabled error="cannot create ICMPv4 proxy: Group ID 0 is not between ping group 1 to 0 nor ICMPv6 proxy: socket: permission denied"
```

Added the needed sysctl settings to the security context to enable this feature and confirmed that the warning is removed.

https://github.com/cloudflare/cloudflared/issues/1109