### PR TITLE
chore(renovate): disable kubernetes monorepo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,5 +30,18 @@
       ],
       "datasourceTemplate": "github-release-attachments"
     }
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "go"
+      ],
+      "matchPackagePrefixes": [
+        "k8s.io/api",
+        "k8s.io/apimachinery",
+        "k8s.io/client-go"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
Better to let `sigs.k8s.io/controller-runtime` transitively update these so that they're in sync