### PR TITLE
fix: verify account-owned API tokens in GatewayClass validation

### DIFF
--- a/internal/controller/gatewayclass_controller.go
+++ b/internal/controller/gatewayclass_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cloudflare/cloudflare-go/v2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,15 +60,28 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// validate parameters
 	msg := ""
-	_, api, err := InitCloudflareAPI(ctx, r.Client, gatewayClass.Name)
+	account, api, err := InitCloudflareAPI(ctx, r.Client, gatewayClass.Name)
 	if err == nil {
-		token, err := api.User.Tokens.Verify(ctx)
-		if err == nil {
+		token, verifyErr := api.User.Tokens.Verify(ctx)
+		if verifyErr == nil {
 			if token.Status != "active" {
 				msg = fmt.Sprintf("Token status is %s, is not active. Please check the Cloudflare dashboard", token.Status)
 			}
+		} else if account != "" {
+			// User-token verification failed (e.g. 401 for an account-owned
+			// token, which didn't exist when /user/tokens/verify was the only
+			// path). Fall back to verifying as an account-owned token against
+			// /accounts/{account_id}/tokens/verify.
+			status, accountErr := verifyAccountToken(ctx, api, account)
+			if accountErr == nil {
+				if status != "active" {
+					msg = fmt.Sprintf("Token status is %s, is not active. Please check the Cloudflare dashboard", status)
+				}
+			} else {
+				msg = verifyErr.Error() + " Ensure ACCOUNT_ID and TOKEN are valid"
+			}
 		} else {
-			msg = err.Error() + " Ensure ACCOUNT_ID and TOKEN are valid"
+			msg = verifyErr.Error() + " Ensure ACCOUNT_ID and TOKEN are valid"
 		}
 	} else {
 		msg = err.Error() + " Ensure ACCOUNT_ID and TOKEN are set"
@@ -98,6 +112,25 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// verifyAccountToken verifies an account-owned Cloudflare API token against
+// GET /accounts/{account_id}/tokens/verify and returns its status. Account
+// tokens didn't exist when /user/tokens/verify was the only verification path,
+// so they 401 against that endpoint. cloudflare-go/v2 v2.4.0 has no typed
+// Accounts.Tokens.Verify, so this uses the client's raw request helper; the
+// REST path and the {"result":{"status":...}} envelope shape are stable across
+// SDK versions, keeping this tolerant of the pending v7 bump.
+func verifyAccountToken(ctx context.Context, api *cloudflare.Client, account string) (string, error) {
+	var env struct {
+		Result struct {
+			Status string `json:"status"`
+		} `json:"result"`
+	}
+	if err := api.Get(ctx, fmt.Sprintf("/accounts/%s/tokens/verify", account), nil, &env); err != nil {
+		return "", err
+	}
+	return env.Result.Status, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/gatewayclass_controller_test.go
+++ b/internal/controller/gatewayclass_controller_test.go
@@ -1,6 +1,14 @@
 package controller
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v2"
+	"github.com/cloudflare/cloudflare-go/v2/option"
 	. "github.com/onsi/ginkgo/v2"
 )
 
@@ -14,3 +22,68 @@ var _ = Describe("GatewayClass Controller", func() {
 		})
 	})
 })
+
+func TestVerifyAccountToken(t *testing.T) {
+	const account = "abc123"
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantStatus string
+		wantErr    bool
+	}{
+		{
+			name:       "active account token",
+			statusCode: http.StatusOK,
+			body:       `{"success":true,"errors":[],"messages":[],"result":{"id":"tok","status":"active"}}`,
+			wantStatus: "active",
+		},
+		{
+			name:       "disabled account token",
+			statusCode: http.StatusOK,
+			body:       `{"success":true,"errors":[],"messages":[],"result":{"id":"tok","status":"disabled"}}`,
+			wantStatus: "disabled",
+		},
+		{
+			name:       "invalid token returns error",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"success":false,"errors":[{"code":1000,"message":"Invalid API Token"}],"result":null}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wantPath := fmt.Sprintf("/accounts/%s/tokens/verify", account)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != wantPath {
+					t.Errorf("unexpected path: got %q, want %q", r.URL.Path, wantPath)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			api := cloudflare.NewClient(
+				option.WithAPIToken("test-token"),
+				option.WithBaseURL(srv.URL),
+			)
+
+			status, err := verifyAccountToken(context.Background(), api, account)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (status %q)", status)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if status != tt.wantStatus {
+				t.Errorf("status = %q, want %q", status, tt.wantStatus)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The `GatewayClass` reconciler validated the configured Cloudflare API token by
calling `GET /user/tokens/verify` only. That endpoint rejects *account-owned*
API tokens with a `401`, so a `GatewayClass` referencing a Secret with a valid
account token reported `Accepted=False` / `InvalidParameters`, even though the
Gateway still programmed its tunnel and routes successfully.

This adds an account-token verification fallback: when the user-token verify
call fails and an `ACCOUNT_ID` is present, the token is re-verified against
`GET /accounts/{account_id}/tokens/verify`. `InvalidParameters` is now only set
when *both* verifications fail, so a valid account token yields `Accepted=True`.
The existing user-token path is unchanged (no regression).

cloudflare-go/v2 has no typed `Accounts.Tokens.Verify`, so the fallback uses the
client's raw request helper (`api.Get`). The REST path and the
`{"result":{"status":...}}` envelope shape are stable across SDK versions,
keeping this tolerant of the pending v7 bump (#276).

## Why this matters

Fixes #262, where an account-owned token produces a misleading `Accepted=False`
status that contradicts actual behaviour (the Gateway reconciles fine). The
maintainer confirmed the intent on the issue: "account tokens didn't exist when
I wrote that. I'll add a verify call and add them to the README." This implements
that verify call. (A README note documenting account-owned tokens is left as a
follow-up; happy to bundle it here if preferred.)

## Testing

- `go build ./...` and `go vet ./...` clean.
- Added `TestVerifyAccountToken`, a hermetic unit test that exercises the
  account-token fallback against an `httptest` server: active and disabled
  statuses decode correctly, and an invalid token surfaces an error.
- `gofmt -l` clean.

Fixes #262

AI was used for assistance.
