### PR TITLE
feat: add health probes to cloudflared

### DIFF
--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -601,7 +601,14 @@ func (r *GatewayReconciler) doFinalizerOperationsForGateway(ctx context.Context,
 func (r *GatewayReconciler) deploymentForGateway(
 	gateway *gatewayv1.Gateway, token string) (*appsv1.Deployment, error) {
 	ls := labelsForGateway(gateway.Name)
-	replicas := int32(2)
+	replicas := int32(1)
+
+	readyProbe := corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Path: "/ready",
+			Port: intstr.IntOrString{IntVal: 2000},
+		},
+	}
 
 	// Get the Operand image
 	image, err := imageForGateway()
@@ -679,17 +686,14 @@ func (r *GatewayReconciler) deploymentForGateway(
 						},
 						Args: []string{"tunnel", "--no-autoupdate", "--metrics", "0.0.0.0:2000", "run", "--token", token},
 						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path: "/ready",
-									Port: intstr.IntOrString{IntVal: 2000},
-								},
-							},
-							// CF recommended probe params
-							// https://developers.cloudflare.com/tunnel/deployment-guides/kubernetes/#5-create-pods-for-cloudflared
-							FailureThreshold: 1,
-							InitialDelaySeconds: 10,
+							ProbeHandler: readyProbe,
+							FailureThreshold: 3,
 							PeriodSeconds: 10,
+						},
+						StartupProbe: &corev1.Probe{
+							ProbeHandler: readyProbe,
+							FailureThreshold: 10,
+							PeriodSeconds: 5,
 						},
 					}},
 				},

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -597,10 +597,11 @@ func (r *GatewayReconciler) doFinalizerOperationsForGateway(ctx context.Context,
 }
 
 // deploymentForGateway returns a Gateway Deployment object
+// deploys cloudflared
 func (r *GatewayReconciler) deploymentForGateway(
 	gateway *gatewayv1.Gateway, token string) (*appsv1.Deployment, error) {
 	ls := labelsForGateway(gateway.Name)
-	replicas := int32(1)
+	replicas := int32(2)
 
 	// Get the Operand image
 	image, err := imageForGateway()
@@ -677,6 +678,19 @@ func (r *GatewayReconciler) deploymentForGateway(
 							},
 						},
 						Args: []string{"tunnel", "--no-autoupdate", "--metrics", "0.0.0.0:2000", "run", "--token", token},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/ready",
+									Port: intstr.IntOrString{IntVal: 2000},
+								},
+							},
+							// CF recommended probe params
+							// https://developers.cloudflare.com/tunnel/deployment-guides/kubernetes/#5-create-pods-for-cloudflared
+							FailureThreshold: 1,
+							InitialDelaySeconds: 10,
+							PeriodSeconds: 10,
+						},
 					}},
 				},
 			},


### PR DESCRIPTION
Closes #180

The CF recommended probe sets `failureThreshold` to 1 after a 10 second grace window, which is kind of aggressive, and might not be appropriate for 1 replica, so I've increased the replica count to 2. 

For reference, here're the probes from my personal 1 replica cloudflared:

```yaml
livenessProbe:
  failureThreshold: 3
  httpGet:
    path: /ready
    port: 2000
    scheme: HTTP
  periodSeconds: 10
  successThreshold: 1
  timeoutSeconds: 1
startupProbe:
  failureThreshold: 5
  httpGet:
    path: /ready
    port: 2000
    scheme: HTTP
  periodSeconds: 5
  successThreshold: 1
  timeoutSeconds: 1
```