### PR TITLE
fix: revert changes to conversion in #300

### DIFF
--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -149,7 +149,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 						namespace = string(*backend.Namespace)
 					}
 
-					services[fmt.Sprintf("http://%s.%s:%d", backend.Name, namespace, backend.Port)] = true
+					services[fmt.Sprintf("http://%s.%s:%d", string(backend.Name), namespace, int32(*backend.Port))] = true
 				}
 
 				// product of hostname, path, service


### PR DESCRIPTION
causes port numbers to overflow