### PR TITLE
chore: extend centralized renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "github>pl4nty/.github"
   ],
   "postUpdateOptions": [
     "gomodTidy"


### PR DESCRIPTION
Swaps `config:recommended` for the centralized preset `github>pl4nty/.github` (`config:best-practices` + `schedule:weekends` + 7-day `minimumReleaseAge` + OSV vulnerability alerts). Custom managers and package rules are kept as-is.

Note: best-practices enables digest pinning, so expect a round of pin PRs after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsPuqPb9iXJfZUD9QiRkzC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsPuqPb9iXJfZUD9QiRkzC)_